### PR TITLE
Fix collection order

### DIFF
--- a/src/Traffic/WidgetsBundle/Entity/FooterWidgets.php
+++ b/src/Traffic/WidgetsBundle/Entity/FooterWidgets.php
@@ -224,6 +224,7 @@ class FooterWidgets
     /**
      * @Assert\NotBlank()
      * @ORM\OneToMany(targetEntity="Traffic\WidgetsBundle\Entity\FooterWidgetsHasMedia", mappedBy="footerWidget",cascade={"persist","remove"} )
+     * @ORM\OrderBy({"position" = "ASC"})
      */
     protected $links;
 


### PR DESCRIPTION
Without

```
 @ORM\OrderBy({"position" = "ASC"})
```

the position field is not used to sort the collection in FooterWidgetAdmin
